### PR TITLE
feat: complete unit tests for all service layers

### DIFF
--- a/src/main/java/com/teamsync/teamsync/controller/StandupController.java
+++ b/src/main/java/com/teamsync/teamsync/controller/StandupController.java
@@ -24,34 +24,34 @@ public class StandupController {
     }
 
     @PostMapping
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<StandupDTO> createStandup(@RequestBody @Valid StandupCreateDTO standup) {
         StandupDTO newStandup = standupService.createStandup(standup);
         return new ResponseEntity<>(newStandup, HttpStatus.CREATED);
     }
 
     @GetMapping
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<StandupDTO>> getAllStandups(@RequestParam(required = false) Long teamId, @RequestParam(required = false) LocalDate date) {
-        return new ResponseEntity<>(standupService.getAllStandups(teamId, date), HttpStatus.OK);
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
+    public ResponseEntity<List<StandupDTO>> getAllStandups(@RequestParam(required = false) LocalDate date) {
+        return new ResponseEntity<>(standupService.getAllStandups(date), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<StandupDTO> getStandupById(@PathVariable Long id) {
         StandupDTO standup = standupService.getStandupById(id);
         return new ResponseEntity<>(standup, HttpStatus.OK);
     }
 
     @PatchMapping("/{id}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<StandupDTO> updateStandup(@PathVariable Long id, @RequestBody @Valid StandupUpdateDTO standup) {
         StandupDTO updated = standupService.updateStandup(id, standup);
         return new ResponseEntity<>(updated, HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<Void> deleteStandup(@PathVariable Long id) {
         standupService.deleteStandup(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/teamsync/teamsync/controller/TeamController.java
+++ b/src/main/java/com/teamsync/teamsync/controller/TeamController.java
@@ -23,33 +23,33 @@ public class TeamController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasRole('MANAGER')")
     public ResponseEntity<TeamDTO> createTeam(@RequestBody @Valid TeamCreateDTO newTeamDTO) {
         TeamDTO newTeam = teamService.createTeam(newTeamDTO);
         return new ResponseEntity<>(newTeam, HttpStatus.CREATED);
     }
 
     @GetMapping
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<List<TeamDTO>> getAllTeams() {
         return ResponseEntity.ok(teamService.getAllTeams());
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('MANAGER', 'TEAM_LEAD', 'TEAM_MEMBER')")
     public ResponseEntity<TeamDTO> getTeamById(@PathVariable Long id) {
         TeamDTO team = teamService.getTeamById(id);
         return ResponseEntity.ok(team);
     }
 
     @PatchMapping("/{id}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasRole('MANAGER')")
     public ResponseEntity<TeamDTO> updateTeam(@PathVariable Long id, @RequestBody @Valid TeamUpdateDTO team) {
         return ResponseEntity.ok(teamService.updateTeam(id, team));
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('MANAGER')")
     public ResponseEntity<Void> deleteTeam(@PathVariable Long id) {
         teamService.deleteTeam(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/teamsync/teamsync/dto/UserUpdateDTO.java
+++ b/src/main/java/com/teamsync/teamsync/dto/UserUpdateDTO.java
@@ -1,7 +1,6 @@
 package com.teamsync.teamsync.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import com.teamsync.teamsync.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,5 +13,6 @@ public class UserUpdateDTO {
     private String fullName;
     private String email;
     private Long teamId;
+    private Role role;
 
 }

--- a/src/main/java/com/teamsync/teamsync/repository/StandupRepository.java
+++ b/src/main/java/com/teamsync/teamsync/repository/StandupRepository.java
@@ -18,4 +18,5 @@ public interface StandupRepository extends JpaRepository<Standup, Long> {
 
     List<Standup> findByTeamIdAndDateBetween(Long teamId, LocalDate dateAfter, LocalDate dateBefore);
 
+    List<Standup> findByUserIdAndDate(Long userId, LocalDate date);
 }

--- a/src/main/java/com/teamsync/teamsync/service/StandupService.java
+++ b/src/main/java/com/teamsync/teamsync/service/StandupService.java
@@ -10,6 +10,7 @@ import com.teamsync.teamsync.exception.BadRequestException;
 import com.teamsync.teamsync.exception.ResourceNotFoundException;
 import com.teamsync.teamsync.repository.StandupRepository;
 import com.teamsync.teamsync.security.CustomUserDetails;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,7 +73,7 @@ public class StandupService {
             }
         }
         else {
-            throw new BadRequestException("Access denied!.");
+            throw new AccessDeniedException("Access denied!.");
         }
 
         return standups.stream().map(this::convertStandupToDTO).toList();
@@ -87,10 +88,10 @@ public class StandupService {
                 );
 
         if (currentUser.getRoleEnum() == Role.TEAM_MEMBER && !standup.getUser().getId().equals(currentUser.getId())) {
-            throw new BadRequestException("You can only view your own standups.");
+            throw new AccessDeniedException("You can only view your own standups.");
         }
         if ((currentUser.getRoleEnum() == Role.TEAM_LEAD || currentUser.getRoleEnum() == Role.MANAGER) && !standup.getTeam().getId().equals(currentUser.getTeamId())) {
-            throw new BadRequestException("You can only view your team's standups.");
+            throw new AccessDeniedException("You can only view your team's standups.");
         }
 
         return convertStandupToDTO(standup);
@@ -106,7 +107,7 @@ public class StandupService {
                 );
 
         if (!exists.getUser().getId().equals(currentUser.getId())) {
-            throw new BadRequestException("You can only update your own standups.");
+            throw new AccessDeniedException("You can only update your own standups.");
         }
 
         if (standup.getYesterday() != null) {
@@ -133,7 +134,7 @@ public class StandupService {
                 );
 
         if (!standup.getUser().getId().equals(currentUser.getId())) {
-            throw new BadRequestException("You can only delete your own standups.");
+            throw new AccessDeniedException("You can only delete your own standups.");
         }
 
         standupRepository.delete(standup);

--- a/src/main/java/com/teamsync/teamsync/service/StandupService.java
+++ b/src/main/java/com/teamsync/teamsync/service/StandupService.java
@@ -33,10 +33,7 @@ public class StandupService {
 
     @Transactional
     public StandupDTO createStandup(StandupCreateDTO standupDTO) {
-        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+        CustomUserDetails currentUser = getCurrentUser();
 
         Standup standup = new Standup();
         standup.setDate(LocalDate.now());
@@ -50,45 +47,50 @@ public class StandupService {
         return convertStandupToDTO(standupRepository.save(standup));
     }
 
-    public List<StandupDTO> getAllStandups(Long teamId, LocalDate date) {
-        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+    public List<StandupDTO> getAllStandups(LocalDate date) {
+        CustomUserDetails currentUser = getCurrentUser();
 
         Long userId = currentUser.getId();
         Role role = currentUser.getRoleEnum();
         List<Standup> standups;
 
         if (role == Role.TEAM_MEMBER) {
-            standups = standupRepository.findByUserId(userId);
+            if (date != null) {
+                standups = standupRepository.findByUserIdAndDate(userId, date);
+            }
+            else {
+                standups = standupRepository.findByUserId(userId);
+            }
+        }
+        else if (role == Role.TEAM_LEAD || role == Role.MANAGER) {
+            Long teamId = currentUser.getTeamId();
+            if (date != null) {
+                standups = standupRepository.findByTeamIdAndDate(teamId, date);
+            }
+            else {
+                standups = standupRepository.findByTeamId(teamId);
+            }
         }
         else {
-            if (teamId != null && date != null) {
-                standups = standupRepository.findByTeamIdAndDate(teamId, date);
-            } else if (teamId != null) {
-                standups = standupRepository.findByTeamId(teamId);
-            } else {
-                throw new IllegalArgumentException("team id is required to fetch standups.");
-            }
+            throw new BadRequestException("Access denied!.");
         }
 
         return standups.stream().map(this::convertStandupToDTO).toList();
     }
 
     public StandupDTO getStandupById(Long id) {
-        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+        CustomUserDetails currentUser = getCurrentUser();
 
         Standup standup = standupRepository.findById(id)
                 .orElseThrow(() ->
                         new ResourceNotFoundException("Standup with id " + id + " not found.")
                 );
 
-        if (!standup.getUser().getId().equals(currentUser.getId())) {
+        if (currentUser.getRoleEnum() == Role.TEAM_MEMBER && !standup.getUser().getId().equals(currentUser.getId())) {
             throw new BadRequestException("You can only view your own standups.");
+        }
+        if ((currentUser.getRoleEnum() == Role.TEAM_LEAD || currentUser.getRoleEnum() == Role.MANAGER) && !standup.getTeam().getId().equals(currentUser.getTeamId())) {
+            throw new BadRequestException("You can only view your team's standups.");
         }
 
         return convertStandupToDTO(standup);
@@ -96,10 +98,7 @@ public class StandupService {
 
     @Transactional
     public StandupDTO updateStandup(Long id, StandupUpdateDTO standup) {
-        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+        CustomUserDetails currentUser = getCurrentUser();
 
         Standup exists = standupRepository.findById(id)
                 .orElseThrow(() ->
@@ -126,10 +125,7 @@ public class StandupService {
 
     @Transactional
     public void deleteStandup(Long id) {
-        CustomUserDetails currentUser = (CustomUserDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+        CustomUserDetails currentUser = getCurrentUser();
 
         Standup standup = standupRepository.findById(id)
                 .orElseThrow(() ->
@@ -153,5 +149,12 @@ public class StandupService {
         standupDTO.setUserId(standup.getUser().getId());
         standupDTO.setTeamId(standup.getTeam().getId());
         return standupDTO;
+    }
+
+    private CustomUserDetails getCurrentUser() {
+        return (CustomUserDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
     }
 }

--- a/src/main/java/com/teamsync/teamsync/service/TeamService.java
+++ b/src/main/java/com/teamsync/teamsync/service/TeamService.java
@@ -8,9 +8,8 @@ import com.teamsync.teamsync.entity.User;
 import com.teamsync.teamsync.enums.Role;
 import com.teamsync.teamsync.exception.ResourceNotFoundException;
 import com.teamsync.teamsync.repository.TeamRepository;
-import com.teamsync.teamsync.repository.UserRepository;
 import com.teamsync.teamsync.security.CustomUserDetails;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +41,12 @@ public class TeamService {
                 .getContext()
                 .getAuthentication()
                 .getPrincipal();
-        if (currentUser.getRoleEnum() == Role.ADMIN || currentUser.getRoleEnum() == Role.MANAGER) {
+
+        if (currentUser.getRoleEnum() == Role.ADMIN) {
+            throw new AccessDeniedException("Access denied.");
+        }
+
+        if (currentUser.getRoleEnum() == Role.MANAGER) {
             return teamRepository.findAll()
                     .stream().map(this::convertTeamToDTO)
                     .toList();

--- a/src/main/java/com/teamsync/teamsync/service/TeamService.java
+++ b/src/main/java/com/teamsync/teamsync/service/TeamService.java
@@ -73,7 +73,7 @@ public class TeamService {
 
         if (role == Role.TEAM_MEMBER || role == Role.TEAM_LEAD) {
             if (currentUser.getTeamId() == null || !currentUser.getTeamId().equals(id)) {
-                throw new ResourceNotFoundException("Access denied: You can only view your team's information.");
+                throw new AccessDeniedException("Access denied: You can only view your team's information.");
             }
         }
 

--- a/src/main/java/com/teamsync/teamsync/service/UserService.java
+++ b/src/main/java/com/teamsync/teamsync/service/UserService.java
@@ -96,6 +96,9 @@ public class UserService {
         if (user.getTeamId() != null) {
             updateUser.setTeam(teamService.getTeamEntityById(user.getTeamId()));
         }
+        if (user.getRole() != null) {
+            updateUser.setRole(user.getRole());
+        }
         return convertUserToDTO(userRepository.save(updateUser));
     }
 

--- a/src/main/java/com/teamsync/teamsync/service/UserService.java
+++ b/src/main/java/com/teamsync/teamsync/service/UserService.java
@@ -104,8 +104,8 @@ public class UserService {
 
     @Transactional
     public void deleteUser(Long id) {
-        getUserEntityById(id);
-        userRepository.deleteById(id);
+        User user = getUserEntityById(id);
+        userRepository.delete(user);
     }
 
     private UserDTO convertUserToDTO(User user) {

--- a/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
@@ -1,0 +1,638 @@
+package com.teamsync.teamsync.service;
+
+import com.teamsync.teamsync.dto.StandupCreateDTO;
+import com.teamsync.teamsync.dto.StandupDTO;
+import com.teamsync.teamsync.dto.StandupUpdateDTO;
+import com.teamsync.teamsync.entity.Standup;
+import com.teamsync.teamsync.entity.Team;
+import com.teamsync.teamsync.entity.User;
+import com.teamsync.teamsync.enums.Role;
+import com.teamsync.teamsync.exception.BadRequestException;
+import com.teamsync.teamsync.exception.ResourceNotFoundException;
+import com.teamsync.teamsync.repository.StandupRepository;
+import com.teamsync.teamsync.security.CustomUserDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StandupServiceTest {
+
+    @Mock
+    private StandupRepository standupRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private TeamService teamService;
+
+    @InjectMocks
+    private StandupService standupService;
+
+    @Test
+    void createStandup_shouldReturnStandupDto_whenUserExists() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        StandupCreateDTO newStandup = new StandupCreateDTO();
+        newStandup.setYesterday("Yesterday");
+        newStandup.setToday("Today");
+        newStandup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId);
+        user.setRole(Role.TEAM_MEMBER);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        Standup savedStandup = new Standup();
+        savedStandup.setId(1L);
+        savedStandup.setYesterday(newStandup.getYesterday());
+        savedStandup.setToday(newStandup.getToday());
+        savedStandup.setBlockers(newStandup.getBlockers());
+        savedStandup.setUser(user);
+        savedStandup.setTeam(team);
+
+        when(userService.getUserEntityById(userId)).thenReturn(user);
+        when(teamService.getTeamEntityById(teamId)).thenReturn(team);
+        when(standupRepository.save(any(Standup.class))).thenReturn(savedStandup);
+
+        StandupDTO result = standupService.createStandup(newStandup);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(newStandup.getYesterday(), result.getYesterday());
+        assertEquals(newStandup.getToday(), result.getToday());
+        assertEquals(newStandup.getBlockers(), result.getBlockers());
+    }
+
+    @Test
+    void createStandup_shouldThrowException_whenUserIsNotFound() {
+
+        Long userId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, null);
+
+        when(userService.getUserEntityById(userId)).thenThrow(new ResourceNotFoundException("User not found"));
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            standupService.createStandup(new StandupCreateDTO());
+        });
+    }
+
+    @Test
+    void getAllStandups_shouldReturnOwnStandupList_whenRoleIsTeamMember() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        Standup standup1 = new Standup();
+        standup1.setId(1L);
+        standup1.setYesterday("Yesterday");
+        standup1.setToday("Today");
+        standup1.setBlockers("Blockers");
+
+        Standup standup2 = new Standup();
+        standup2.setId(2L);
+        standup2.setYesterday("Yesterday");
+        standup2.setToday("Today");
+        standup2.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup1.setUser(user);
+        standup1.setTeam(team);
+
+        standup2.setUser(user);
+        standup2.setTeam(team);
+
+        when(standupRepository.findByUserId(userId)).thenReturn(List.of(standup1, standup2));
+
+        List<StandupDTO> result = standupService.getAllStandups(null);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals(2L, result.get(1).getId());
+    }
+
+    @Test
+    void getAllStandups_shouldReturnTeamStandupList_whenRoleIsTeamLead() {
+
+        Long leadId = 1L;
+        Long memberId = 2L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, leadId, teamId);
+
+        Standup standup1 = new Standup();
+        standup1.setId(1L);
+        standup1.setYesterday("Yesterday");
+        standup1.setToday("Today");
+        standup1.setBlockers("Blockers");
+
+        Standup standup2 = new Standup();
+        standup2.setId(2L);
+        standup2.setYesterday("Yesterday");
+        standup2.setToday("Today");
+        standup2.setBlockers("Blockers");
+
+        User lead = new User();
+        lead.setId(leadId);
+
+        User member = new User();
+        member.setId(memberId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup1.setUser(lead);
+        standup1.setTeam(team);
+
+        standup2.setUser(member);
+        standup2.setTeam(team);
+
+        when(standupRepository.findByTeamId(teamId)).thenReturn(List.of(standup1, standup2));
+
+        List<StandupDTO> result = standupService.getAllStandups(null);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals(2L, result.get(1).getId());
+    }
+
+    @Test
+    void getAllStandups_shouldReturnTeamStandupList_whenRoleIsManager() {
+
+        Long managerId = 1L;
+        Long leadId = 2L;
+        Long memberId = 3L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.MANAGER, managerId, teamId);
+
+        Standup standup1 = new Standup();
+        standup1.setId(2L);
+        standup1.setYesterday("Yesterday");
+        standup1.setToday("Today");
+        standup1.setBlockers("Blockers");
+
+        Standup standup2 = new Standup();
+        standup2.setId(3L);
+        standup2.setYesterday("Yesterday");
+        standup2.setToday("Today");
+        standup2.setBlockers("Blockers");
+
+        User lead = new User();
+        lead.setId(leadId);
+
+        User member = new User();
+        member.setId(memberId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup1.setUser(lead);
+        standup1.setTeam(team);
+
+        standup2.setUser(member);
+        standup2.setTeam(team);
+
+        User manager = new User();
+        manager.setId(managerId);
+
+        when(standupRepository.findByTeamId(teamId)).thenReturn(List.of(standup1, standup2));
+
+        List<StandupDTO> result = standupService.getAllStandups(null);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(2L, result.get(0).getId());
+        assertEquals(3L, result.get(1).getId());
+    }
+
+    @Test
+    void getAllStandups_shouldThrowException_whenRoleIsInvalid() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.ADMIN, userId, teamId);
+
+        assertThrows(BadRequestException.class, () -> {
+            standupService.getAllStandups(null);
+        });
+    }
+
+    @Test
+    void getAllStandups_shouldReturnOwnStandupList_whenRoleIsTeamMemberAndDateProvided() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        Standup standup1 = new Standup();
+        standup1.setId(1L);
+        standup1.setYesterday("Yesterday");
+        standup1.setToday("Today");
+        standup1.setBlockers("Blockers");
+        standup1.setDate(LocalDate.now());
+
+        User user = new User();
+        user.setId(userId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup1.setUser(user);
+        standup1.setTeam(team);
+
+        when(standupRepository.findByUserIdAndDate(userId, LocalDate.now())).thenReturn(List.of(standup1));
+
+        List<StandupDTO> result = standupService.getAllStandups(LocalDate.now());
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getId());
+    }
+
+    @Test
+    void getAllStandups_shouldReturnTeamStandupList_whenRoleIsTeamLeadAndDateProvided() {
+
+        Long leadId = 1L;
+        Long memberId = 2L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, leadId, teamId);
+
+        Standup standup1 = new Standup();
+        standup1.setId(1L);
+        standup1.setYesterday("Yesterday");
+        standup1.setToday("Today");
+        standup1.setBlockers("Blockers");
+        standup1.setDate(LocalDate.now());
+
+        Standup standup2 = new Standup();
+        standup2.setId(2L);
+        standup2.setYesterday("Yesterday");
+        standup2.setToday("Today");
+        standup2.setBlockers("Blockers");
+        standup2.setDate(LocalDate.now());
+
+        User lead = new User();
+        lead.setId(leadId);
+
+        User member = new User();
+        member.setId(memberId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup1.setUser(lead);
+        standup1.setTeam(team);
+
+        standup2.setUser(member);
+        standup2.setTeam(team);
+
+        when(standupRepository.findByTeamIdAndDate(teamId, LocalDate.now())).thenReturn(List.of(standup1, standup2));
+
+        List<StandupDTO> result = standupService.getAllStandups(LocalDate.now());
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals(2L, result.get(1).getId());
+    }
+
+    @Test
+    void getStandupById_shouldReturnStandupDto_whenTeamMemberViewsOwnStandup() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        Standup standup = new Standup();
+        standup.setId(1L);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup.setUser(user);
+        standup.setTeam(team);
+
+        when(standupRepository.findById(1L)).thenReturn(Optional.of(standup));
+
+        StandupDTO result = standupService.getStandupById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Yesterday", result.getYesterday());
+        assertEquals("Today", result.getToday());
+        assertEquals("Blockers", result.getBlockers());
+        assertEquals(userId, result.getUserId());
+        assertEquals(teamId, result.getTeamId());
+    }
+
+    @Test
+    void getStandupById_shouldThrowException_whenTeamMemberViewsOtherStandup() {
+
+        Long userId = 2L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        Standup standup = new Standup();
+        standup.setId(1L);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(1L);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup.setUser(user);
+        standup.setTeam(team);
+
+        when(standupRepository.findById(1L)).thenReturn(Optional.of(standup));
+
+        assertThrows(BadRequestException.class, () -> {
+            standupService.getStandupById(1L);
+        });
+    }
+
+    @Test
+    void getStandupById_shouldReturnStandupDto_whenTeamLeadViewsTeamStandup() {
+
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, userId1, teamId);
+
+        Standup standup = new Standup();
+        standup.setId(1L);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId2);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup.setUser(user);
+        standup.setTeam(team);
+
+        when(standupRepository.findById(1L)).thenReturn(Optional.of(standup));
+
+        StandupDTO result = standupService.getStandupById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Yesterday", result.getYesterday());
+        assertEquals("Today", result.getToday());
+        assertEquals("Blockers", result.getBlockers());
+        assertEquals(userId2, result.getUserId());
+        assertNotEquals(userId1, result.getUserId());
+        assertEquals(teamId, result.getTeamId());
+    }
+
+    @Test
+    void getStandupById_shouldThrowException_whenStandupNotFound() {
+
+        Long userId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, null);
+
+        when(standupRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            standupService.getStandupById(1L);
+        });
+    }
+
+    @Test
+    void updateStandup_shouldReturnUpdatedStandupDto_whenOwnerUpdates() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        StandupUpdateDTO updateStandupDto = new StandupUpdateDTO();
+        updateStandupDto.setYesterday("Updated Yesterday");
+        updateStandupDto.setToday("Updated Today");
+        updateStandupDto.setBlockers("Updated Blockers");
+
+        Standup standup = new Standup();
+        standup.setId(standupId);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup.setUser(user);
+        standup.setTeam(team);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
+        when(standupRepository.save(any(Standup.class))).thenReturn(standup);
+
+        StandupDTO result = standupService.updateStandup(standupId, updateStandupDto);
+
+        ArgumentCaptor<Standup> captor = ArgumentCaptor.forClass(Standup.class);
+        verify(standupRepository).save(captor.capture());
+        Standup updatedStandup = captor.getValue();
+        assertEquals(standupId, updatedStandup.getId());
+        assertEquals("Updated Yesterday", updatedStandup.getYesterday());
+        assertEquals("Updated Today", updatedStandup.getToday());
+        assertEquals("Updated Blockers", updatedStandup.getBlockers());
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Updated Yesterday", result.getYesterday());
+        assertEquals("Updated Today", result.getToday());
+        assertEquals("Updated Blockers", result.getBlockers());
+        assertEquals(userId, result.getUserId());
+        assertEquals(teamId, result.getTeamId());
+    }
+
+    @Test
+    void updateStandup_shouldThrowException_whenNonOwnerUpdates() {
+
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId1, null);
+
+        StandupUpdateDTO updateStandupDto = new StandupUpdateDTO();
+        updateStandupDto.setYesterday("Updated Yesterday");
+        updateStandupDto.setToday("Updated Today");
+        updateStandupDto.setBlockers("Updated Blockers");
+
+        Standup standup = new Standup();
+        standup.setId(standupId);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId2);
+
+        standup.setUser(user);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
+
+        assertThrows(BadRequestException.class, () -> {
+            standupService.updateStandup(standupId, updateStandupDto);
+        });
+    }
+
+    @Test
+    void updateStandup_shouldThrowException_whenStandupNotFound() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            standupService.updateStandup(standupId, new StandupUpdateDTO());
+        });
+    }
+
+    @Test
+    void deleteStandup_shouldDeleteStandup_whenOwnerDeletes() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        Standup standup = new Standup();
+        standup.setId(standupId);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId);
+
+        Team team = new Team();
+        team.setId(teamId);
+
+        standup.setUser(user);
+        standup.setTeam(team);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
+
+        standupService.deleteStandup(standupId);
+
+        verify(standupRepository).delete(standup);
+    }
+
+    @Test
+    void deleteStandup_shouldThrowException_whenNonOwnerDeletes() {
+
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId1, null);
+
+        Standup standup = new Standup();
+        standup.setId(standupId);
+        standup.setYesterday("Yesterday");
+        standup.setToday("Today");
+        standup.setBlockers("Blockers");
+
+        User user = new User();
+        user.setId(userId2);
+
+        standup.setUser(user);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
+
+        assertThrows(BadRequestException.class, () -> {
+            standupService.deleteStandup(standupId);
+        });
+    }
+
+    @Test
+    void deleteStandup_shouldThrowException_whenStandupNotFound() {
+
+        Long userId = 1L;
+        Long teamId = 1L;
+        Long standupId = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, userId, teamId);
+
+        when(standupRepository.findById(standupId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            standupService.deleteStandup(standupId);
+        });
+    }
+
+    private void setSecurityContext(Role role, Long userId, Long teamId) {
+
+        CustomUserDetails mockUser = new CustomUserDetails(
+                userId, "test@test.com", "password", role.name(), teamId,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                mockUser, null, mockUser.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}

--- a/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
@@ -7,7 +7,6 @@ import com.teamsync.teamsync.entity.Standup;
 import com.teamsync.teamsync.entity.Team;
 import com.teamsync.teamsync.entity.User;
 import com.teamsync.teamsync.enums.Role;
-import com.teamsync.teamsync.exception.BadRequestException;
 import com.teamsync.teamsync.exception.ResourceNotFoundException;
 import com.teamsync.teamsync.repository.StandupRepository;
 import com.teamsync.teamsync.security.CustomUserDetails;
@@ -17,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -246,7 +246,7 @@ class StandupServiceTest {
 
         setSecurityContext(Role.ADMIN, userId, teamId);
 
-        assertThrows(BadRequestException.class, () -> {
+        assertThrows(AccessDeniedException.class, () -> {
             standupService.getAllStandups(null);
         });
     }
@@ -393,7 +393,7 @@ class StandupServiceTest {
 
         when(standupRepository.findById(1L)).thenReturn(Optional.of(standup));
 
-        assertThrows(BadRequestException.class, () -> {
+        assertThrows(AccessDeniedException.class, () -> {
             standupService.getStandupById(1L);
         });
     }
@@ -528,7 +528,7 @@ class StandupServiceTest {
 
         when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
 
-        assertThrows(BadRequestException.class, () -> {
+        assertThrows(AccessDeniedException.class, () -> {
             standupService.updateStandup(standupId, updateStandupDto);
         });
     }
@@ -602,7 +602,7 @@ class StandupServiceTest {
 
         when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
 
-        assertThrows(BadRequestException.class, () -> {
+        assertThrows(AccessDeniedException.class, () -> {
             standupService.deleteStandup(standupId);
         });
     }

--- a/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/StandupServiceTest.java
@@ -27,8 +27,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StandupServiceTest {
@@ -65,25 +64,34 @@ class StandupServiceTest {
         Team team = new Team();
         team.setId(teamId);
 
-        Standup savedStandup = new Standup();
-        savedStandup.setId(1L);
-        savedStandup.setYesterday(newStandup.getYesterday());
-        savedStandup.setToday(newStandup.getToday());
-        savedStandup.setBlockers(newStandup.getBlockers());
-        savedStandup.setUser(user);
-        savedStandup.setTeam(team);
-
         when(userService.getUserEntityById(userId)).thenReturn(user);
         when(teamService.getTeamEntityById(teamId)).thenReturn(team);
-        when(standupRepository.save(any(Standup.class))).thenReturn(savedStandup);
+        when(standupRepository.save(any(Standup.class)))
+                .thenAnswer(invocation -> {
+                    Standup s = invocation.getArgument(0);
+                    s.setId(1L);
+                    return s;
+                });
 
         StandupDTO result = standupService.createStandup(newStandup);
+
+        verify(userService).getUserEntityById(userId);
+        verify(teamService).getTeamEntityById(teamId);
+
+        ArgumentCaptor<Standup> captor = ArgumentCaptor.forClass(Standup.class);
+        verify(standupRepository).save(captor.capture());
+        Standup savedStandup = captor.getValue();
+        assertEquals(newStandup.getYesterday(), savedStandup.getYesterday());
+        assertEquals(newStandup.getToday(), savedStandup.getToday());
+        assertEquals(newStandup.getBlockers(), savedStandup.getBlockers());
 
         assertNotNull(result);
         assertEquals(1L, result.getId());
         assertEquals(newStandup.getYesterday(), result.getYesterday());
         assertEquals(newStandup.getToday(), result.getToday());
         assertEquals(newStandup.getBlockers(), result.getBlockers());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -98,6 +106,11 @@ class StandupServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             standupService.createStandup(new StandupCreateDTO());
         });
+
+        verify(userService).getUserEntityById(userId);
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -136,10 +149,14 @@ class StandupServiceTest {
 
         List<StandupDTO> result = standupService.getAllStandups(null);
 
+        verify(standupRepository).findByUserId(userId);
+
         assertNotNull(result);
         assertEquals(2, result.size());
         assertEquals(1L, result.get(0).getId());
         assertEquals(2L, result.get(1).getId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -182,10 +199,14 @@ class StandupServiceTest {
 
         List<StandupDTO> result = standupService.getAllStandups(null);
 
+        verify(standupRepository).findByTeamId(teamId);
+
         assertNotNull(result);
         assertEquals(2, result.size());
         assertEquals(1L, result.get(0).getId());
         assertEquals(2L, result.get(1).getId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -232,10 +253,14 @@ class StandupServiceTest {
 
         List<StandupDTO> result = standupService.getAllStandups(null);
 
+        verify(standupRepository).findByTeamId(teamId);
+
         assertNotNull(result);
         assertEquals(2, result.size());
         assertEquals(2L, result.get(0).getId());
         assertEquals(3L, result.get(1).getId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -249,6 +274,10 @@ class StandupServiceTest {
         assertThrows(AccessDeniedException.class, () -> {
             standupService.getAllStandups(null);
         });
+
+        verifyNoInteractions(standupRepository);
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -279,9 +308,13 @@ class StandupServiceTest {
 
         List<StandupDTO> result = standupService.getAllStandups(LocalDate.now());
 
+        verify(standupRepository).findByUserIdAndDate(userId, LocalDate.now());
+
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals(1L, result.get(0).getId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -326,10 +359,14 @@ class StandupServiceTest {
 
         List<StandupDTO> result = standupService.getAllStandups(LocalDate.now());
 
+        verify(standupRepository).findByTeamIdAndDate(teamId, LocalDate.now());
+
         assertNotNull(result);
         assertEquals(2, result.size());
         assertEquals(1L, result.get(0).getId());
         assertEquals(2L, result.get(1).getId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -359,6 +396,8 @@ class StandupServiceTest {
 
         StandupDTO result = standupService.getStandupById(1L);
 
+        verify(standupRepository).findById(1L);
+
         assertNotNull(result);
         assertEquals(1L, result.getId());
         assertEquals("Yesterday", result.getYesterday());
@@ -366,6 +405,8 @@ class StandupServiceTest {
         assertEquals("Blockers", result.getBlockers());
         assertEquals(userId, result.getUserId());
         assertEquals(teamId, result.getTeamId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -396,6 +437,10 @@ class StandupServiceTest {
         assertThrows(AccessDeniedException.class, () -> {
             standupService.getStandupById(1L);
         });
+
+        verify(standupRepository).findById(1L);
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -426,6 +471,8 @@ class StandupServiceTest {
 
         StandupDTO result = standupService.getStandupById(1L);
 
+        verify(standupRepository).findById(1L);
+
         assertNotNull(result);
         assertEquals(1L, result.getId());
         assertEquals("Yesterday", result.getYesterday());
@@ -434,6 +481,8 @@ class StandupServiceTest {
         assertEquals(userId2, result.getUserId());
         assertNotEquals(userId1, result.getUserId());
         assertEquals(teamId, result.getTeamId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -448,6 +497,10 @@ class StandupServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             standupService.getStandupById(1L);
         });
+
+        verify(standupRepository).findById(1L);
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -480,25 +533,30 @@ class StandupServiceTest {
         standup.setTeam(team);
 
         when(standupRepository.findById(standupId)).thenReturn(Optional.of(standup));
-        when(standupRepository.save(any(Standup.class))).thenReturn(standup);
+        when(standupRepository.save(any(Standup.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
         StandupDTO result = standupService.updateStandup(standupId, updateStandupDto);
+
+        verify(standupRepository).findById(standupId);
 
         ArgumentCaptor<Standup> captor = ArgumentCaptor.forClass(Standup.class);
         verify(standupRepository).save(captor.capture());
         Standup updatedStandup = captor.getValue();
         assertEquals(standupId, updatedStandup.getId());
-        assertEquals("Updated Yesterday", updatedStandup.getYesterday());
-        assertEquals("Updated Today", updatedStandup.getToday());
-        assertEquals("Updated Blockers", updatedStandup.getBlockers());
+        assertEquals(updateStandupDto.getYesterday(), updatedStandup.getYesterday());
+        assertEquals(updateStandupDto.getToday(), updatedStandup.getToday());
+        assertEquals(updateStandupDto.getBlockers(), updatedStandup.getBlockers());
 
         assertNotNull(result);
         assertEquals(1L, result.getId());
-        assertEquals("Updated Yesterday", result.getYesterday());
-        assertEquals("Updated Today", result.getToday());
-        assertEquals("Updated Blockers", result.getBlockers());
+        assertEquals(updateStandupDto.getYesterday(), result.getYesterday());
+        assertEquals(updateStandupDto.getToday(), result.getToday());
+        assertEquals(updateStandupDto.getBlockers(), result.getBlockers());
         assertEquals(userId, result.getUserId());
         assertEquals(teamId, result.getTeamId());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -531,6 +589,11 @@ class StandupServiceTest {
         assertThrows(AccessDeniedException.class, () -> {
             standupService.updateStandup(standupId, updateStandupDto);
         });
+
+        verify(standupRepository).findById(standupId);
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -547,6 +610,11 @@ class StandupServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             standupService.updateStandup(standupId, new StandupUpdateDTO());
         });
+
+        verify(standupRepository).findById(standupId);
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -577,7 +645,11 @@ class StandupServiceTest {
 
         standupService.deleteStandup(standupId);
 
+        verify(standupRepository).findById(standupId);
         verify(standupRepository).delete(standup);
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -605,6 +677,12 @@ class StandupServiceTest {
         assertThrows(AccessDeniedException.class, () -> {
             standupService.deleteStandup(standupId);
         });
+
+        verify(standupRepository).findById(standupId);
+        verify(standupRepository, never()).delete(standup);
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -621,6 +699,12 @@ class StandupServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             standupService.deleteStandup(standupId);
         });
+
+        verify(standupRepository).findById(standupId);
+        verify(standupRepository, never()).delete(any());
+        verify(standupRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     private void setSecurityContext(Role role, Long userId, Long teamId) {

--- a/src/test/java/com/teamsync/teamsync/service/TeamServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/TeamServiceTest.java
@@ -1,0 +1,170 @@
+package com.teamsync.teamsync.service;
+
+import com.teamsync.teamsync.dto.TeamCreateDTO;
+import com.teamsync.teamsync.dto.TeamDTO;
+import com.teamsync.teamsync.entity.Team;
+import com.teamsync.teamsync.enums.Role;
+import com.teamsync.teamsync.enums.TeamCategory;
+import com.teamsync.teamsync.repository.TeamRepository;
+import com.teamsync.teamsync.security.CustomUserDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    void createTeam_shouldReturnTeamDto_whenTeamIsCreated() {
+
+        TeamCreateDTO newTeam = new TeamCreateDTO();
+        newTeam.setName("Test Team");
+        newTeam.setDescription("This is a test team");
+        newTeam.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.save(any(Team.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TeamDTO result = teamService.createTeam(newTeam);
+
+        ArgumentCaptor<Team> captor = ArgumentCaptor.forClass(Team.class);
+        verify(teamRepository).save(captor.capture());
+        Team savedTeam = captor.getValue();
+
+        assertNotNull(result);
+        assertEquals("Test Team", savedTeam.getName());
+        assertEquals("This is a test team", savedTeam.getDescription());
+        assertEquals(TeamCategory.TESTING, savedTeam.getCategory());
+    }
+
+    @Test
+    void getAllTeams_shouldThrowException_whenRoleIsAdmin() {
+
+        long userId = 1L;
+        Long teamId = null;
+
+        setSecurityContext(Role.ADMIN, userId, teamId);
+
+        assertThrows(AccessDeniedException.class, () ->
+                teamService.getAllTeams()
+        );
+    }
+
+    @Test
+    void getAllTeams_shouldReturnAllTeams_whenRoleIsManager() {
+
+        long userId = 1L;
+        Long teamId = null;
+
+        setSecurityContext(Role.MANAGER, userId, teamId);
+
+        Team team1 = new Team();
+        team1.setId(1L);
+        team1.setName("Team 1");
+        team1.setDescription("This is team 1");
+        team1.setCategory(TeamCategory.TESTING);
+
+        Team team2 = new Team();
+        team2.setId(2L);
+        team2.setName("Team 2");
+        team2.setDescription("This is team 2");
+        team2.setCategory(TeamCategory.DEVELOPMENT);
+
+        when(teamRepository.findAll()).thenReturn(List.of(team1, team2));
+
+        List<TeamDTO> result = teamService.getAllTeams();
+
+        verify(teamRepository).findAll();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("Team 1", result.get(0).getName());
+        assertEquals("This is team 1", result.get(0).getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.get(0).getCategory());
+
+        assertEquals("Team 2", result.get(1).getName());
+        assertEquals("This is team 2", result.get(1).getDescription());
+        assertEquals(TeamCategory.DEVELOPMENT.name(), result.get(1).getCategory());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getAllTeams_shouldReturnOwnTeams_whenRoleIsTeamLead() {
+
+        long userId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, userId, teamId);
+
+        Team team1 = new Team();
+        team1.setId(teamId);
+        team1.setName("Team 1");
+        team1.setDescription("This is team 1");
+        team1.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team1));
+
+        List<TeamDTO> result = teamService.getAllTeams();
+
+        verify(teamRepository).findById(teamId);
+        verify(teamRepository, never()).findAll();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Team 1", result.get(0).getName());
+        assertEquals("This is team 1", result.get(0).getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.get(0).getCategory());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getTeamEntityById() {
+    }
+
+    @Test
+    void getTeamById() {
+    }
+
+    @Test
+    void updateTeam() {
+    }
+
+    @Test
+    void deleteTeam() {
+    }
+
+    private void setSecurityContext(Role role, Long userId, Long teamId) {
+
+        CustomUserDetails mockuser = new CustomUserDetails(
+                userId, "test@test.com", "password", role.name(), teamId,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                mockuser, null, mockuser.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}

--- a/src/test/java/com/teamsync/teamsync/service/TeamServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/TeamServiceTest.java
@@ -2,9 +2,11 @@ package com.teamsync.teamsync.service;
 
 import com.teamsync.teamsync.dto.TeamCreateDTO;
 import com.teamsync.teamsync.dto.TeamDTO;
+import com.teamsync.teamsync.dto.TeamUpdateDTO;
 import com.teamsync.teamsync.entity.Team;
 import com.teamsync.teamsync.enums.Role;
 import com.teamsync.teamsync.enums.TeamCategory;
+import com.teamsync.teamsync.exception.ResourceNotFoundException;
 import com.teamsync.teamsync.repository.TeamRepository;
 import com.teamsync.teamsync.security.CustomUserDetails;
 import org.junit.jupiter.api.Test;
@@ -43,24 +45,34 @@ class TeamServiceTest {
         newTeam.setCategory(TeamCategory.TESTING);
 
         when(teamRepository.save(any(Team.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                .thenAnswer(invocation -> {
+                    Team t = invocation.getArgument(0);
+                    t.setId(1L);
+                    return t;
+                });
 
         TeamDTO result = teamService.createTeam(newTeam);
 
         ArgumentCaptor<Team> captor = ArgumentCaptor.forClass(Team.class);
         verify(teamRepository).save(captor.capture());
         Team savedTeam = captor.getValue();
-
-        assertNotNull(result);
         assertEquals("Test Team", savedTeam.getName());
         assertEquals("This is a test team", savedTeam.getDescription());
         assertEquals(TeamCategory.TESTING, savedTeam.getCategory());
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Test Team",  result.getName());
+        assertEquals("This is a test team", result.getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.getCategory());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
     void getAllTeams_shouldThrowException_whenRoleIsAdmin() {
 
-        long userId = 1L;
+        Long userId = 1L;
         Long teamId = null;
 
         setSecurityContext(Role.ADMIN, userId, teamId);
@@ -68,12 +80,14 @@ class TeamServiceTest {
         assertThrows(AccessDeniedException.class, () ->
                 teamService.getAllTeams()
         );
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
     void getAllTeams_shouldReturnAllTeams_whenRoleIsManager() {
 
-        long userId = 1L;
+        Long userId = 1L;
         Long teamId = null;
 
         setSecurityContext(Role.MANAGER, userId, teamId);
@@ -112,7 +126,7 @@ class TeamServiceTest {
     @Test
     void getAllTeams_shouldReturnOwnTeams_whenRoleIsTeamLead() {
 
-        long userId = 1L;
+        Long userId = 1L;
         Long teamId = 1L;
 
         setSecurityContext(Role.TEAM_LEAD, userId, teamId);
@@ -128,7 +142,6 @@ class TeamServiceTest {
         List<TeamDTO> result = teamService.getAllTeams();
 
         verify(teamRepository).findById(teamId);
-        verify(teamRepository, never()).findAll();
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -140,19 +153,257 @@ class TeamServiceTest {
     }
 
     @Test
-    void getTeamEntityById() {
+    void getTeamById_shouldReturnTeamDTO_whenManagerAccessAnyTeam() {
+
+        Long managerId = 1L;
+        Long teamId1 = 1L;
+        Long teamId2 = 2L;
+
+        setSecurityContext(Role.MANAGER, managerId, teamId1);
+
+        Team team1 = new Team();
+        team1.setId(teamId1);
+        team1.setName("Team 1");
+        team1.setDescription("This is team 1");
+        team1.setCategory(TeamCategory.TESTING);
+
+        Team team2 = new Team();
+        team2.setId(teamId2);
+        team2.setName("Team 2");
+        team2.setDescription("This is team 2");
+        team2.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId2)).thenReturn(Optional.of(team2));
+
+        TeamDTO result = teamService.getTeamById(teamId2);
+
+        verify(teamRepository).findById(teamId2);
+
+        assertNotNull(result);
+        assertEquals("Team 2", result.getName());
+        assertEquals("This is team 2", result.getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.getCategory());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
-    void getTeamById() {
+    void getTeamById_shouldReturnTeamDTO_whenTeamLeadAccessesOwnTeam() {
+
+        Long teamLeadId = 1L;
+        Long teamId1 = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, teamLeadId, teamId1);
+
+        Team team1 = new Team();
+        team1.setId(teamId1);
+        team1.setName("Team 1");
+        team1.setDescription("This is team 1");
+        team1.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId1)).thenReturn(Optional.of(team1));
+
+        TeamDTO result = teamService.getTeamById(teamId1);
+
+        verify(teamRepository).findById(teamId1);
+
+        assertNotNull(result);
+        assertEquals("Team 1", result.getName());
+        assertEquals("This is team 1", result.getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.getCategory());
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
-    void updateTeam() {
+    void getTeamById_shouldThrowException_whenTeamLeadAccessesOtherTeam() {
+
+        Long teamLeadId = 1L;
+        Long teamId1 = 1L;
+        Long teamId2 = 2L;
+
+        setSecurityContext(Role.TEAM_LEAD, teamLeadId, teamId1);
+
+        assertThrows(AccessDeniedException.class, () ->
+                teamService.getTeamById(teamId2)
+        );
+
+        verifyNoInteractions(teamRepository);
+
+        SecurityContextHolder.clearContext();
     }
 
     @Test
-    void deleteTeam() {
+    void getTeamById_shouldReturnTeamDTO_whenTeamMemberAccessesOwnTeam() {
+
+        Long teamLeadId = 1L;
+        Long teamId1 = 1L;
+
+        setSecurityContext(Role.TEAM_MEMBER, teamLeadId, teamId1);
+
+        Team team1 = new Team();
+        team1.setId(teamId1);
+        team1.setName("Team 1");
+        team1.setDescription("This is team 1");
+        team1.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId1)).thenReturn(Optional.of(team1));
+
+        TeamDTO result = teamService.getTeamById(teamId1);
+
+        verify(teamRepository).findById(teamId1);
+
+        assertNotNull(result);
+        assertEquals("Team 1", result.getName());
+        assertEquals("This is team 1", result.getDescription());
+        assertEquals(TeamCategory.TESTING.name(), result.getCategory());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getTeamById_shouldThrowException_whenTeamMemberAccessesOtherTeam() {
+
+        Long teamLeadId = 1L;
+        Long teamId1 = 1L;
+        Long teamId2 = 2L;
+
+        setSecurityContext(Role.TEAM_MEMBER, teamLeadId, teamId1);
+
+        assertThrows(AccessDeniedException.class, () ->
+                teamService.getTeamById(teamId2)
+        );
+
+        verifyNoInteractions(teamRepository);
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getTeamById_shouldThrowException_whenTeamNotFound() {
+
+        Long teamLeadId = 1L;
+        Long teamId = 1L;
+
+        setSecurityContext(Role.MANAGER, teamLeadId, null);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () ->
+                teamService.getTeamById(teamId)
+        );
+
+        verify(teamRepository).findById(teamId);
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void updateTeam_shouldReturnTeamDTO_whenTeamExists() {
+
+        Long teamId = 1L;
+        Long managerId = 1L;
+
+        setSecurityContext(Role.MANAGER, managerId, teamId);
+
+        TeamUpdateDTO updateDto = new TeamUpdateDTO();
+        updateDto.setName("Updated Team 1");
+        updateDto.setDescription("This is updated team 1");
+        updateDto.setCategory(TeamCategory.DEVELOPMENT);
+
+        Team team = new Team();
+        team.setId(teamId);
+        team.setName("Team 1");
+        team.setDescription("This is team 1");
+        team.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(teamRepository.save(any(Team.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TeamDTO result = teamService.updateTeam(teamId, updateDto);
+        
+        verify(teamRepository).findById(teamId);
+
+        ArgumentCaptor<Team> captor = ArgumentCaptor.forClass(Team.class);
+        verify(teamRepository).save(captor.capture());
+        Team updatedTeam = captor.getValue();
+        assertEquals(teamId, updatedTeam.getId());
+        assertEquals(updateDto.getName(), updatedTeam.getName());
+        assertEquals(updateDto.getDescription(), updatedTeam.getDescription());
+        assertEquals(updateDto.getCategory(), updatedTeam.getCategory());
+
+        assertNotNull(result);
+        assertEquals(updateDto.getName(), result.getName());
+        assertEquals(updateDto.getDescription(), result.getDescription());
+        assertEquals(updateDto.getCategory().name(), result.getCategory());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void updateTeam_shouldThrowException_whenTeamNotFound() {
+
+        Long teamId = 1L;
+        Long managerId = 1L;
+
+        setSecurityContext(Role.MANAGER, managerId, null);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () ->
+                teamService.updateTeam(teamId, new TeamUpdateDTO())
+        );
+
+        verify(teamRepository).findById(teamId);
+        verify(teamRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void deleteTeam_shouldDeleteTeam_whenTeamExists() {
+
+        Long teamId = 1L;
+        Long managerId = 1L;
+
+        setSecurityContext(Role.MANAGER, managerId, teamId);
+
+        Team team = new Team();
+        team.setId(teamId);
+        team.setName("Team 1");
+        team.setDescription("This is team 1");
+        team.setCategory(TeamCategory.TESTING);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+        teamService.deleteTeam(teamId);
+
+        verify(teamRepository).findById(teamId);
+        verify(teamRepository).deleteById(teamId);
+        verify(teamRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void deleteTeam_shouldThrowException_whenTeamNotFound() {
+
+        Long teamId = 1L;
+        Long managerId = 1L;
+
+        setSecurityContext(Role.MANAGER, managerId, null);
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () ->
+                teamService.deleteTeam(teamId)
+        );
+
+        verify(teamRepository).findById(teamId);
+        verify(teamRepository, never()).save(any());
+
+        SecurityContextHolder.clearContext();
     }
 
     private void setSecurityContext(Role role, Long userId, Long teamId) {

--- a/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import com.teamsync.teamsync.repository.UserRepository;
 import com.teamsync.teamsync.security.CustomUserDetails;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -189,7 +190,6 @@ class UserServiceTest {
         user3.setFullName("Sophie Best");
         user3.setEmail("sophie.best@test.com");
         user3.setRole(Role.MANAGER);
-
         user3.setTeam(team);
 
         when(userRepository.findByTeamId(teamId)).thenReturn(List.of(user1, user2, user3));
@@ -251,13 +251,18 @@ class UserServiceTest {
 
         User savedUser = new User();
         savedUser.setId(userId);
-        savedUser.setFullName(updateDTO.getFullName());
+        savedUser.setFullName("Alex Mark");
         savedUser.setRole(Role.TEAM_MEMBER);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(savedUser));
         when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
         UserDTO result = userService.updateUser(userId, updateDTO);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User updatedUser = captor.getValue();
+        assertEquals("Alexa Mark", updatedUser.getFullName());
 
         assertNotNull(result);
         assertEquals(userId, result.getId());
@@ -288,7 +293,7 @@ class UserServiceTest {
 
         userService.deleteUser(userId);
 
-        verify(userRepository).deleteById(userId);
+        verify(userRepository).delete(user);
     }
 
     @Test

--- a/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
@@ -1,0 +1,318 @@
+package com.teamsync.teamsync.service;
+
+import com.teamsync.teamsync.dto.UserCreateDTO;
+import com.teamsync.teamsync.dto.UserDTO;
+import com.teamsync.teamsync.dto.UserUpdateDTO;
+import com.teamsync.teamsync.entity.Team;
+import com.teamsync.teamsync.entity.User;
+import com.teamsync.teamsync.enums.Role;
+import com.teamsync.teamsync.exception.BadRequestException;
+import com.teamsync.teamsync.exception.ResourceNotFoundException;
+import com.teamsync.teamsync.repository.UserRepository;
+import com.teamsync.teamsync.security.CustomUserDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamService teamService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createUser_shouldReturnUserDto_whenEmailDoesNotExists() {
+
+        UserCreateDTO newUser = new UserCreateDTO();
+        newUser.setFullName("Alex Mark");
+        newUser.setEmail("alex.mark@test.com");
+        newUser.setRole(Role.TEAM_MEMBER);
+        newUser.setTeamId(1L);
+
+        User savedUser = new User();
+        savedUser.setId(1L);
+        savedUser.setFullName(newUser.getFullName());
+        savedUser.setEmail(newUser.getEmail());
+        savedUser.setRole(newUser.getRole());
+
+        Team team = new Team();
+        team.setId(newUser.getTeamId());
+        team.setName("Test Team");
+
+        savedUser.setTeam(team);
+
+        when(userRepository.existsByEmail(newUser.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+        when(teamService.getTeamEntityById(newUser.getTeamId())).thenReturn(team);
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        UserDTO result = userService.createUser(newUser);
+
+        assertNotNull(result);
+        assertEquals("Alex Mark", result.getFullName());
+        assertEquals("alex.mark@test.com", result.getEmail());
+    }
+
+    @Test
+    void createUser_shouldThrowException_whenEmailAlreadyExists() {
+
+        UserCreateDTO newUser = new UserCreateDTO();
+        newUser.setFullName("Alex Mark");
+        newUser.setEmail("alex.mark@test.com");
+        newUser.setRole(Role.TEAM_MEMBER);
+        newUser.setTeamId(1L);
+
+        when(userRepository.existsByEmail(newUser.getEmail())).thenReturn(true);
+
+        assertThrows(BadRequestException.class, () -> {
+            userService.createUser(newUser);
+        });
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAllUsers_whenUserIsAdmin() {
+
+        setSecurityContext(Role.ADMIN, null);
+
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setFullName("Alex Mark");
+        user1.setEmail("alex.mark@test.com");
+        user1.setRole(Role.TEAM_MEMBER);
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setFullName("David Rolo");
+        user2.setEmail("david.rolo@test.com");
+        user2.setRole(Role.TEAM_LEAD);
+
+        User user3 = new User();
+        user3.setId(3L);
+        user3.setFullName("Sophie Best");
+        user3.setEmail("sophie.best@test.com");
+        user3.setRole(Role.MANAGER);
+
+        when(userRepository.findAll()).thenReturn(List.of(user1, user2, user3));
+
+        List<UserDTO> result = userService.getAllUsers();
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAllUsers_whenUserIsManager() {
+
+        setSecurityContext(Role.MANAGER, null);
+
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setFullName("Alex Mark");
+        user1.setEmail("alex.mark@test.com");
+        user1.setRole(Role.TEAM_MEMBER);
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setFullName("David Rolo");
+        user2.setEmail("david.rolo@test.com");
+        user2.setRole(Role.TEAM_LEAD);
+
+        User user3 = new User();
+        user3.setId(3L);
+        user3.setFullName("Sophie Best");
+        user3.setEmail("sophie.best@test.com");
+        user3.setRole(Role.MANAGER);
+
+        when(userRepository.findAll()).thenReturn(List.of(user1, user2, user3));
+
+        List<UserDTO> result = userService.getAllUsers();
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAllUsers_whenUserIsTeamLead() {
+
+        Long teamId = 1L;
+
+        setSecurityContext(Role.TEAM_LEAD, teamId);
+
+        Team team = new Team();
+        team.setId(teamId);
+        team.setName("Test Team");
+
+        User user1 = new User();
+        user1.setId(1L);
+        user1.setFullName("Alex Mark");
+        user1.setEmail("alex.mark@test.com");
+        user1.setRole(Role.TEAM_MEMBER);
+        user1.setTeam(team);
+
+        User user2 = new User();
+        user2.setId(2L);
+        user2.setFullName("David Rolo");
+        user2.setEmail("david.rolo@test.com");
+        user2.setRole(Role.TEAM_LEAD);
+        user2.setTeam(team);
+
+        User user3 = new User();
+        user3.setId(3L);
+        user3.setFullName("Sophie Best");
+        user3.setEmail("sophie.best@test.com");
+        user3.setRole(Role.MANAGER);
+
+        user3.setTeam(team);
+
+        when(userRepository.findByTeamId(teamId)).thenReturn(List.of(user1, user2, user3));
+
+        List<UserDTO> result = userService.getAllUsers();
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        SecurityContextHolder.clearContext();
+    }
+
+    /*
+        Same as getUserById. Also, it is indirectly tested.
+     */
+    @Test
+    void getUserEntityById() {
+    }
+
+    @Test
+    void getUserById_shouldReturnUserDto_whenUserExists() {
+
+        Long userId = 1L;
+
+        User user = new User();
+        user.setId(userId);
+        user.setFullName("Alex Mark");
+        user.setEmail("alex.mark@test.com");
+        user.setRole(Role.TEAM_MEMBER);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        UserDTO result = userService.getUserById(userId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.getId());
+        assertEquals("Alex Mark", result.getFullName());
+    }
+
+    @Test
+    void getUserById_shouldThrowException_whenUserDoesNotExists() {
+
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            userService.getUserById(1L);
+        });
+    }
+
+    @Test
+    void updateUser_shouldReturnUpdatedUserDto_whenUserExists() {
+
+        Long userId = 1L;
+
+        UserUpdateDTO updateDTO = new UserUpdateDTO();
+        updateDTO.setFullName("Alexa Mark");
+
+        User savedUser = new User();
+        savedUser.setId(userId);
+        savedUser.setFullName(updateDTO.getFullName());
+        savedUser.setRole(Role.TEAM_MEMBER);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(savedUser));
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        UserDTO result = userService.updateUser(userId, updateDTO);
+
+        assertNotNull(result);
+        assertEquals(userId, result.getId());
+        assertEquals("Alexa Mark", result.getFullName());
+    }
+
+    @Test
+    void updateUser_shouldThrowException_whenUserDoesNotExists() {
+
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            userService.updateUser(userId, new UserUpdateDTO());
+        });
+    }
+
+    @Test
+    void deleteUser_shouldDeleteUser_whenUserExists() {
+
+        Long userId = 1L;
+
+        User user = new User();
+        user.setId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        userService.deleteUser(userId);
+
+        verify(userRepository).deleteById(userId);
+    }
+
+    @Test
+    void deleteUser_shouldThrowException_whenUserDoesNotExists() {
+
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            userService.deleteUser(userId);
+        });
+    }
+
+    private void setSecurityContext(Role role, Long teamId) {
+
+        CustomUserDetails mockUser = new CustomUserDetails(
+                1L, "test@test.com", "password", role.name(), teamId,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                mockUser, null, mockUser.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+}

--- a/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
+++ b/src/test/java/com/teamsync/teamsync/service/UserServiceTest.java
@@ -27,8 +27,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -69,9 +68,21 @@ class UserServiceTest {
         when(userRepository.existsByEmail(newUser.getEmail())).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
         when(teamService.getTeamEntityById(newUser.getTeamId())).thenReturn(team);
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userRepository.save(any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
         UserDTO result = userService.createUser(newUser);
+
+        verify(userRepository).existsByEmail(newUser.getEmail());
+        verify(passwordEncoder).encode(anyString());
+        verify(teamService).getTeamEntityById(newUser.getTeamId());
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User user = captor.getValue();
+        assertEquals(newUser.getFullName(), user.getFullName());
+        assertEquals(newUser.getEmail(), user.getEmail());
+        assertEquals(newUser.getRole(), user.getRole());
 
         assertNotNull(result);
         assertEquals("Alex Mark", result.getFullName());
@@ -92,6 +103,9 @@ class UserServiceTest {
         assertThrows(BadRequestException.class, () -> {
             userService.createUser(newUser);
         });
+
+        verify(userRepository).existsByEmail(newUser.getEmail());
+        verify(userRepository, never()).save(any());
     }
 
     @Test
@@ -121,8 +135,13 @@ class UserServiceTest {
 
         List<UserDTO> result = userService.getAllUsers();
 
+        verify(userRepository).findAll();
+
         assertNotNull(result);
         assertEquals(3, result.size());
+        assertEquals("Alex Mark", result.get(0).getFullName());
+        assertEquals("David Rolo", result.get(1).getFullName());
+        assertEquals("Sophie Best", result.get(2).getFullName());
 
         SecurityContextHolder.clearContext();
     }
@@ -154,8 +173,13 @@ class UserServiceTest {
 
         List<UserDTO> result = userService.getAllUsers();
 
+        verify(userRepository).findAll();
+
         assertNotNull(result);
         assertEquals(3, result.size());
+        assertEquals("Alex Mark", result.get(0).getFullName());
+        assertEquals("David Rolo", result.get(1).getFullName());
+        assertEquals("Sophie Best", result.get(2).getFullName());
 
         SecurityContextHolder.clearContext();
     }
@@ -196,17 +220,15 @@ class UserServiceTest {
 
         List<UserDTO> result = userService.getAllUsers();
 
+        verify(userRepository).findByTeamId(teamId);
+
         assertNotNull(result);
         assertEquals(3, result.size());
+        assertEquals("Alex Mark", result.get(0).getFullName());
+        assertEquals("David Rolo", result.get(1).getFullName());
+        assertEquals("Sophie Best", result.get(2).getFullName());
 
         SecurityContextHolder.clearContext();
-    }
-
-    /*
-        Same as getUserById. Also, it is indirectly tested.
-     */
-    @Test
-    void getUserEntityById() {
     }
 
     @Test
@@ -224,9 +246,12 @@ class UserServiceTest {
 
         UserDTO result = userService.getUserById(userId);
 
+        verify(userRepository).findById(userId);
+
         assertNotNull(result);
         assertEquals(userId, result.getId());
         assertEquals("Alex Mark", result.getFullName());
+        assertEquals("alex.mark@test.com",  result.getEmail());
     }
 
     @Test
@@ -239,6 +264,8 @@ class UserServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             userService.getUserById(1L);
         });
+
+        verify(userRepository).findById(userId);
     }
 
     @Test
@@ -255,18 +282,21 @@ class UserServiceTest {
         savedUser.setRole(Role.TEAM_MEMBER);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(savedUser));
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userRepository.save(any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
         UserDTO result = userService.updateUser(userId, updateDTO);
+
+        verify(userRepository).findById(userId);
 
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(captor.capture());
         User updatedUser = captor.getValue();
-        assertEquals("Alexa Mark", updatedUser.getFullName());
+        assertEquals(updateDTO.getFullName(), updatedUser.getFullName());
 
         assertNotNull(result);
         assertEquals(userId, result.getId());
-        assertEquals("Alexa Mark", result.getFullName());
+        assertEquals(updateDTO.getFullName(), result.getFullName());
     }
 
     @Test
@@ -279,6 +309,9 @@ class UserServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             userService.updateUser(userId, new UserUpdateDTO());
         });
+
+        verify(userRepository).findById(userId);
+        verify(userRepository, never()).save(any());
     }
 
     @Test
@@ -293,7 +326,9 @@ class UserServiceTest {
 
         userService.deleteUser(userId);
 
+        verify(userRepository).findById(userId);
         verify(userRepository).delete(user);
+        verify(userRepository, never()).save(any());
     }
 
     @Test
@@ -306,6 +341,10 @@ class UserServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             userService.deleteUser(userId);
         });
+
+        verify(userRepository).findById(userId);
+        verify(userRepository, never()).delete(any());
+        verify(userRepository, never()).save(any());
     }
 
     private void setSecurityContext(Role role, Long teamId) {


### PR DESCRIPTION
## Summary
- Added unit tests for UserService, StandupService and TeamService
- 44 tests total covering happy path, exception and role-based scenarios
- Fixed role-based access control throughout services and controllers
- Fixed AccessDeniedException vs BadRequestException misuse
- Updated getAllStandups, getAllTeams, getAllUsers with proper role filtering
- Fixed deleteUser to use delete(entity) instead of deleteById

## Tests Added
- UserService: 11 tests
- StandupService: 18 tests  
- TeamService: 14 tests
- Integration: 1 test