### PR TITLE
feat: add Docker and docker-compose for containerisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_USER=your_db_username
+DB_PASSWORD=your_db_password
+POSTGRES_DB=teamsync
+JWT_SECRET=your_jwt_secret_min_64_chars
+JWT_EXPIRATION=86400000

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 *.iws
 *.iml
 *.ipr
+.env
 
 ### NetBeans ###
 /nbproject/private/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=linux/amd64 eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+COPY target/teamsync-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/teamsync
+      - SPRING_DATASOURCE_USERNAME=${DB_USER}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=${JWT_EXPIRATION}
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>teamsync</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>TeamSync</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Daily standup automation backend built with Spring Boot, JWT, and PostgreSQL</description>
 	<url/>
 	<licenses>
 		<license/>


### PR DESCRIPTION
Add Docker containerisation for TeamSync

- Add Dockerfile using  eclipse-temurin:17-jre-alpine base image
- Add docker-compose.yml to run app and PostgreSQL together
- Add .env.example template for environment variable setup
- Update .gitignore to exclude .env file
- Update pom.xml description

To run locally:
1. Copy .env.example to .env and fill in your values
2. Run: docker-compose up --build

Note: Dockerfile uses --platform=linux/amd64 flag for compatibility 
with Apple Silicon (M1/M2/M3) Macs running Docker Desktop.